### PR TITLE
concept-demo.py 의 학년과 학기가 같은 데이터의 노드가 겹치는 문제 해결

### DIFF
--- a/ai-concept-demo/concept-demo.py
+++ b/ai-concept-demo/concept-demo.py
@@ -11,10 +11,36 @@ def read_subjects(filename):
         data = yaml.safe_load(file)
     return data.get('과목', [])
 
+# 학년과 학기가 같은 강좌에 대한 좌표 조정 함수
+def adjust_coordinates(subjects):
+    adjusted_pos = {}
+    for subject in subjects:
+        grade = subject['학년']
+        semester = subject['학기']
+        pos_key = (grade, semester)
+        if pos_key in adjusted_pos:
+            adjusted_pos[pos_key].append(0)
+        else:
+            adjusted_pos[pos_key] = [0]
+    # 겹치는 노드중 하나만 이동하도록 조정 하는 함수
+    for pos_key, positions in adjusted_pos.items():
+        num_positions = len(positions)
+        if num_positions > 1:
+            spacing = 0.4
+            for i in range(num_positions):
+                adjusted_pos[pos_key][i] = (i - (num_positions - 1) / 2) * spacing
+    return adjusted_pos
+
 def draw_course_structure(subjects):
     G = nx.DiGraph()
+    adjusted_pos = adjust_coordinates(subjects)
     for subject in subjects:
-        G.add_node(subject['과목명'], pos=(subject['학년'], subject['학기']))
+        grade = subject['학년']
+        semester = subject['학기']
+        #x,y 좌표 조정
+        x = grade + adjusted_pos[(grade, semester)].pop(0)  
+        y = semester
+        G.add_node(subject['과목명'], pos=(x, y))
         if '선수과목' in subject:
             for prereq in subject['선수과목']:
                 G.add_edge(prereq, subject['과목명'])


### PR DESCRIPTION
adjust_coordinates 함수를 추가해 학년과 학기의 키 값이 동일한 강의를 선별하고, 겹치는 노드 중 하나만 이동하도록 하는 함수를 만들었습니다.

동일한 키 값을 가지고 있는 노드가 생길경우 키 값에 0을 추가하여 새로운 키 값을 만들어내 좌표를 조정하도록 설계하였습니다.
키 값이 변경되어진 노드는 spacing 부분의 값을 조정하여 위치를 조정할 수 있습니다.

이에 draw_course_structure 함수의 노드 좌표를 x, y로 설정하고 pos를 x, y 좌표로 조정해 변경이 쉽게 만들었습니다.

다만 현재 그려지는 노드의 크기가 커 노드의 크기와 글씨를 조금 줄여야할거같습니다.
(테스트해본 결과로는 node_size 1500, font_size 8 이 적당해보였습니다.)