### PR TITLE
패키지 자동설치

### DIFF
--- a/ai-concept-demo/concept-demo.py
+++ b/ai-concept-demo/concept-demo.py
@@ -1,3 +1,6 @@
+import subprocess
+# requirements.txt 파일의 내용을 읽어와서 필요한 패키지들을 자동으로 설치합니다.
+subprocess.check_call(["pip", "install", "-r", "requirements.txt"])
 import strictyaml
 import networkx as nx
 import matplotlib.pyplot as plt


### PR DESCRIPTION
파이썬을 설치할 때 기본으로 설치되는 subprocess를 이용하여 별도의 install 명령어를 작성하지 않아도 파일 실행만 하면 필요한 패키지들이 자동 설치되게끔 수정하였습니다.
IDE 환경에 따라서 import 명령어가 먼저 실행되어 디버깅시 오류가 발생하는 것을 확인했습니다. 따라서 코드를 최상단에 위치시켰습니다.
* resolved: #32 