### PR TITLE
show_table 과 show_graph 에서 중복된 함수는 삭제하고 show_common.py 에서 호출하여 사용할 수 있게 코드 수정

### DIFF
--- a/coursegraph/ show_common.py
+++ b/coursegraph/ show_common.py
@@ -1,0 +1,37 @@
+import sys
+import os
+import strictyaml as syaml
+from fontutil import get_system_font
+
+class CommonProcessor:
+    def __init__(self):
+        self.script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    def read_yaml(self, filename):
+        try:
+            with open(filename, 'r', encoding='UTF8') as file:
+                yaml_data = file.read()
+                data = syaml.load(yaml_data).data
+                return data
+        except FileNotFoundError:
+            print("파일을 찾을 수 없습니다.", file=sys.stderr)
+            return None
+        except Exception as e:
+            print(f"파일을 읽는 중 오류가 발생했습니다: {e}", file=sys.stderr)
+            return None
+
+    def get_system_font(self):
+        try:
+            return get_system_font()[1]['file']
+        except:
+            try:
+                return get_system_font()[0]['file']
+            except:
+                try:
+                    return get_system_font()[2]['file']
+                except:
+                    print("시스템내에 적합한 한글 폰트 파일을 찾을 수 없습니다.", file=sys.stderr)
+                    sys.exit(2)
+
+if __name__ == "__main__":
+    common_processor = CommonProcessor()

--- a/coursegraph/ show_common.py
+++ b/coursegraph/ show_common.py
@@ -3,35 +3,35 @@ import os
 import strictyaml as syaml
 from fontutil import get_system_font
 
-class CommonProcessor:
-    def __init__(self):
-        self.script_dir = os.path.dirname(os.path.abspath(__file__))
+def get_script_dir():
+    return os.path.dirname(os.path.abspath(__file__))
 
-    def read_yaml(self, filename):
-        try:
-            with open(filename, 'r', encoding='UTF8') as file:
-                yaml_data = file.read()
-                data = syaml.load(yaml_data).data
-                return data
-        except FileNotFoundError:
-            print("파일을 찾을 수 없습니다.", file=sys.stderr)
-            return None
-        except Exception as e:
-            print(f"파일을 읽는 중 오류가 발생했습니다: {e}", file=sys.stderr)
-            return None
+def read_yaml(filename):
+    script_dir = get_script_dir()
+    try:
+        with open(os.path.join(script_dir, filename), 'r', encoding='UTF8') as file:
+            yaml_data = file.read()
+            data = syaml.load(yaml_data).data
+            return data
+    except FileNotFoundError:
+        print("파일을 찾을 수 없습니다.", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"파일을 읽는 중 오류가 발생했습니다: {e}", file=sys.stderr)
+        return None
 
-    def get_system_font(self):
+def get_system_font():
+    try:
+        return get_system_font()[1]['file']
+    except:
         try:
-            return get_system_font()[1]['file']
+            return get_system_font()[0]['file']
         except:
             try:
-                return get_system_font()[0]['file']
+                return get_system_font()[2]['file']
             except:
-                try:
-                    return get_system_font()[2]['file']
-                except:
-                    print("시스템내에 적합한 한글 폰트 파일을 찾을 수 없습니다.", file=sys.stderr)
-                    sys.exit(2)
+                print("시스템내에 적합한 한글 폰트 파일을 찾을 수 없습니다.", file=sys.stderr)
+                sys.exit(2)
 
 if __name__ == "__main__":
-    common_processor = CommonProcessor()
+    script_dir = get_script_dir()

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -1,13 +1,14 @@
 import networkx as nx
 import matplotlib.pyplot as plt
 import sys
-from show_common import CommonProcessor
+from show_common import read_yaml, get_system_font
 from fontutil import get_system_font
-
-common_processor = CommonProcessor()
 
 # 학년과 학기가 같은 강좌에 대한 좌표 조정 함수
 def adjust_coordinates(subjects):
+    script_dir = get_script_dir()
+    font_name = get_system_font()
+
     adjusted_pos = {}
     for subject in subjects:
         grade = int(subject['학년'])
@@ -27,7 +28,7 @@ def adjust_coordinates(subjects):
     return adjusted_pos
 
 def draw_course_structure(subjects, output_file):
-    font_name = common_processor.get_system_font()
+    font_name = get_system_font()
         
     G = nx.DiGraph()
     adjusted_pos = adjust_coordinates(subjects)

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -4,6 +4,10 @@ import sys
 from show_common import read_yaml, get_system_font
 from fontutil import get_system_font
 
+ def read_subjects(self):
+        subjects = read_yaml(self.filename)
+        return subjects
+
 # 학년과 학기가 같은 강좌에 대한 좌표 조정 함수
 def adjust_coordinates(subjects):
     script_dir = get_script_dir()

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -1,21 +1,10 @@
-import strictyaml
 import networkx as nx
 import matplotlib.pyplot as plt
 import sys
+from show_common import CommonProcessor
 from fontutil import get_system_font
 
-def read_subjects(filename):
-    try:
-        with open(filename, 'r', encoding='UTF8') as file:
-            yaml_data = file.read()
-            data = strictyaml.load(yaml_data)
-            return data['과목']
-    except FileNotFoundError:
-        print("해당하는 파일이 없습니다.", file=sys.stderr)
-        return None
-    except strictyaml.YAMLValidationError as e:
-        print(f"YAML 데이터가 잘못되어있습니다: {e}", file=sys.stderr)
-        return None
+common_processor = CommonProcessor()
 
 # 학년과 학기가 같은 강좌에 대한 좌표 조정 함수
 def adjust_coordinates(subjects):
@@ -38,7 +27,7 @@ def adjust_coordinates(subjects):
     return adjusted_pos
 
 def draw_course_structure(subjects, output_file):
-    font_name = get_system_font()[0]['name']
+    font_name = common_processor.get_system_font()
         
     G = nx.DiGraph()
     adjusted_pos = adjust_coordinates(subjects)

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import matplotlib.pyplot as plt
 import sys
-from show_common import read_yaml, get_system_font
+from show_common import read_yaml, get_system_font, get_script_dir
 from fontutil import get_system_font
 
  def read_subjects(self):

--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -1,12 +1,11 @@
 import pandas as pd
-import strictyaml as syaml
 import os
-
 import platform
 import matplotlib.pyplot as plt
-from fontutil import get_system_font
-from matplotlib import font_manager, rc
+from show_common import CommonProcessor
 
+# CommonProcessor 인스턴스 생성
+common_processor = CommonProcessor()
 
 class ShowTable:
     def __init__(self, image_mode, input_filepath, output_filename):
@@ -20,35 +19,13 @@ class ShowTable:
         input_filename = input("yaml 파일을 입력하세요 (예: me.yaml은 me 입력): ")
         filename = os.path.join(self.script_dir, '../data/', input_filename + '.yaml')
         return filename
-
-    def get_system_font(self):
-        try:
-            return get_system_font()[1]['file']
-        except:
-            try:
-                return get_system_font()[0]['file']
-            except:
-                try:
-                    return get_system_font()[2]['file']
-                except:
-                    print("시스템내에 적합한 한글 폰트 파일을 찾을 수 없습니다.")
-                    sys.exit(2)
                     
     def read_subjects(self):
-        try:
-            with open(self.filename, 'r', encoding='UTF8') as file:
-                yaml_data = file.read()
-                data = syaml.load(yaml_data).data
-                return data
-        except FileNotFoundError:
-            print("파일을 찾을 수 없습니다.")
-            return None
-        except Exception as e:
-            print("파일을 읽는 중 오류가 발생했습니다:", e)
-            return None
+         subjects = common_processor.read_yaml(self.filename)
+         return subjects
 
     def make_data(self, data):
-        font_name = font_manager.FontProperties(fname=self.font_path).get_name()
+        font_name = common_processor.get_system_font()
         rc('font', family=font_name)
 
         if '과목' in data:

--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -2,7 +2,7 @@ import pandas as pd
 import os
 import platform
 import matplotlib.pyplot as plt
-from show_common import read_yaml, get_system_font, get_script_dir
+from show_common import read_yaml, get_system_font
 
 class ShowTable:
     def __init__(self, image_mode, input_filepath, output_filename):

--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -2,10 +2,7 @@ import pandas as pd
 import os
 import platform
 import matplotlib.pyplot as plt
-from show_common import CommonProcessor
-
-# CommonProcessor 인스턴스 생성
-common_processor = CommonProcessor()
+from show_common import read_yaml, get_system_font, get_script_dir
 
 class ShowTable:
     def __init__(self, image_mode, input_filepath, output_filename):
@@ -21,11 +18,11 @@ class ShowTable:
         return filename
                     
     def read_subjects(self):
-         subjects = common_processor.read_yaml(self.filename)
-         return subjects
+        subjects = read_yaml(self.filename)
+        return subjects
 
     def make_data(self, data):
-        font_name = common_processor.get_system_font()
+        font_name = get_system_font()
         rc('font', family=font_name)
 
         if '과목' in data:


### PR DESCRIPTION
show_graph 와 show_table 에서 겹치는 get_system_font() 와 read_subjects() 함수를 show_common에 class CommonProcessor: 로 호출할 수 있게 수정하였기에 
- show_table.py 와 show_graph 에from show_common import read_yaml, get_system_font함수를 추가
- show_graph 의 경우 
      def adjust_coordinates(subjects):
           script_dir = get_script_dir()
           font_name = get_system_font()
     def draw_course_structure(subjects, output_file):
            font_name = get_system_font()
-  show_table 의 경우  
   def read_subjects(self):
         subjects = read_yaml(self.filename)
         return subjects

   def make_data(self, data):
        font_name = get_system_font()
         return subjects 

위와 같이 수정하였습니다. 