### PR TITLE
테이블 출력시 일정 부분이 잘리는 현상 수정

### DIFF
--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -60,6 +60,7 @@ class ShowTable:
             if self.image_mode:
                 if self.output_filename:
                     plt.savefig(self.output_filename)
+            plt.tight_layout()
             plt.show()
         else:
             print("데이터에 '과목' 정보가 없습니다.")


### PR DESCRIPTION
show_table.py에서 plt.tight_layout()함수를 사용하여 내용에 맞춰 화면을 출력하게끔 수정하였습니다.