### PR TITLE
스키마 오류 수정

### DIFF
--- a/coursegraph/schema_checker.py
+++ b/coursegraph/schema_checker.py
@@ -12,11 +12,11 @@ def validate_string_or_sequence(value):
         for item in value:  # 리스트 내 각 항목을 확인
             if not isinstance(item, str):
                 raise ValueError("올바른 형식이 아닙니다.")
-            if not re.match(r'^[A-Za-z가-힣\w.]+$', item):
+            if not re.match(r'^[A-Za-z가-힣\w./]+$', item):
                 raise ValueError("올바른 형식이 아닙니다.")
         return value
     elif isinstance(value, str):
-        if re.match(r'^[A-Za-z가-힣\w.]+$', value):
+        if re.match(r'^[A-Za-z가-힣\w./]+$', value):
             return value
         else:
             raise ValueError("올바른 형식이 아닙니다.")


### PR DESCRIPTION
#225 
/가 특수문자로 인정받지 못해 /를 추가했습니다.

참고로 [A-Za-z가-힣\w./] 이 부분을 수정했는데,
A-Za-z : 영문 대소문자 모두를 문자열로 인식,
가-힣 : 한글 문자 범위,
\w : 모든 영숫자(알파벳 대소문자 및 숫자)와 밑줄 문자('_')
. : 마침표 문자입니다.
여기서 /를 추가하였습니다.