### PR TITLE
schema_checker.py 에서 학년이 1~6 에 없는 경우 에러 발생하게 수정

### DIFF
--- a/coursegraph/schema_checker.py
+++ b/coursegraph/schema_checker.py
@@ -43,6 +43,8 @@ def validate_yaml(file_path):
             for index, subject in enumerate(data["과목"], start=1):
                 subject_name = subject["과목명"]
                 try:
+                    if subject["학년"] not in [1, 2, 3, 4, 5, 6]:
+                        raise ValueError("학년은 1부터 6까지의 정수여야 합니다.")
                     for field_name in ["과목명", "트랙", "마이크로디그리", "선수과목"]:
                         if field_name in subject:
                             validate_string_or_sequence(subject[field_name].data)


### PR DESCRIPTION
기존 코드에서 def validate_yaml(file_path): 함수의 try 문에 if subject["학년"] not in [1, 2, 3, 4, 5, 6]:  raise ValueError("학년은 1부터 6까지의 정수여야 합니다.") 의 코드를 추가하여 학년이 1~6 학년이 아닌 경우 error가 발생하게 수정하였습니다. 

이렇게 되면 실수로 음수나 소수점 등을 입력을 하더라도 1,2,3,4,5,6 이 아니기에 에러가 발생합니다. 