### PR TITLE
gui2.ui 를 Maingui.ui로 변경

### DIFF
--- a/coursegraph/gui.py
+++ b/coursegraph/gui.py
@@ -3,7 +3,7 @@ from PyQt5.QtWidgets import *
 from PyQt5 import uic
 
 #ui 파일이 실행파일과 같은 위치에 있어야함.
-form_class = uic.loadUiType("gui2.ui")[0]
+form_class = uic.loadUiType("Maingui.ui")[0]
 
 #화면을 띄우는데 사용되는 Class 선언
 class WindowClass(QMainWindow, form_class) :


### PR DESCRIPTION
#246
위의 이슈 내용을 고치기 위해
gui.py의 6번째 줄에
    form_class = uic.loadUiType("gui2.ui")[0]에서 "gui2.ui"를 같은 디렉토리에 있는 "Maingui.ui"로 변경하였습니다.
그 결과 cmd 창에서 python gui.py 실행 시 gui화면이 뜨게 되었습니다.