### PR TITLE
다른 이름으로 저장 기능 추가

### DIFF
--- a/coursegraph/Maingui.ui
+++ b/coursegraph/Maingui.ui
@@ -32,14 +32,14 @@
       <item row="1" column="0">
        <widget class="QPushButton" name="pushButton">
         <property name="text">
-         <string>PushButton</string>
+         <string>이미지 없애기</string>
         </property>
        </widget>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>TextLabel</string>
+         <string></string>
         </property>
        </widget>
       </item>

--- a/coursegraph/gui.py
+++ b/coursegraph/gui.py
@@ -1,21 +1,24 @@
 import sys
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import *
 from PyQt5 import uic
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QLabel
 
-#ui 파일이 실행파일과 같은 위치에 있어야함.
+# ui 파일이 실행 파일과 같은 위치에 있어야 함.
 form_class = uic.loadUiType("Maingui.ui")[0]
 
-#화면을 띄우는데 사용되는 Class 선언
-class WindowClass(QMainWindow, form_class) :
-    def __init__(self) :
+# 화면을 띄우는데 사용되는 Class 선언
+class WindowClass(QMainWindow, form_class):
+    def __init__(self):
         super().__init__()
         self.setupUi(self)
 
-        self.action_open.triggered.connect(self.openFunction)
+        self.action_open.triggered.connect(self.openFunction) 
+        self.action_othernamesave.triggered.connect(self.saveAsFunction) 
         self.gridLayout_3.addWidget(self.label, 0, 0)
-    
+        self.pushButton.clicked.connect(self.clearImage)
+
+        
     def openFunction(self):
         filename, _ = QFileDialog.getOpenFileName(self, "Open Image", "", "Image Files (*.png *.jpg *.bmp *.gif)")
         if filename:  # 파일이 선택되었는지 확인
@@ -28,20 +31,28 @@ class WindowClass(QMainWindow, form_class) :
         else:
             QMessageBox.warning(self, "파일을 선택하지 않았습니다.")
 
-    #def saveFunction(self): #현재 미구현
-    #    fname = QFileDialog.getOpenFileName(self)
-    #    with open(fname[0], 'w', encoding = 'UTF8') as f:
-    #        data = f.write()
-    #    
-    #    print(fname)
+    def clearImage(self):
+        self.label.clear()  # QLabel에 표시된 이미지 제거
 
-# 에러 발생시 정상 종료하도록 정의
+    def saveAsFunction(self):
+        try:
+            filename, _ = QFileDialog.getSaveFileName(self, "Save Image As", "", "PNG Files (*.png);;JPEG Files (*.jpg);;BMP Files (*.bmp);;GIF Files (*.gif)")
+            if filename:  # 파일이 선택되었는지 확인
+                pixmap = self.label.pixmap()  # QLabel에 표시된 이미지 가져오기
+                if pixmap:
+                    pixmap.save(filename)  # 이미지를 지정된 파일 경로에 저장
+                else:
+                    QMessageBox.warning(self, "Warning", "이미지가 없습니다.", QMessageBox.Ok)
+        except TypeError:
+            QMessageBox.warning(self, "Warning", "파일 저장에 실패했습니다.", QMessageBox.Ok)
+
+# 에러 발생 시 정상 종료하도록 정의
 def exception_hook(exctype, value, traceback):
     print(exctype, value, traceback)
     sys.exit(1)
 
 sys.excepthook = exception_hook
-app = QApplication(sys.argv) 
-myWindow = WindowClass() 
+app = QApplication(sys.argv)
+myWindow = WindowClass()
 myWindow.show()
 app.exec_()


### PR DESCRIPTION
gui.py에서 다른 이름으로 저장이 가능하도록 수정했습니다.
그리고 파일을 열지 않고 다른이름으로 저장을 하려고 하면 warning메시지가 뜨게 수정했습니다.
![sfasfsaffsaff](https://github.com/oss2024hnu/coursegraph-py/assets/82097844/3af0b762-d52a-456d-8c82-da3f726a1539)
파일을 열지 않은 상태에서 저장을 할 경우
![스크린샷 2024-05-14 safasfsafafsdfasfs](https://github.com/oss2024hnu/coursegraph-py/assets/82097844/be27d6ee-aa91-4c7e-a16d-d2d283bbce83)
warning메시지가 출력됩니다.
그리고 pushbutton을 이미지 초기화 버튼으로 수정해서 버튼을 누르면 연 이미지를 없앨 수 있습니다.
![스크린샷 2024-05-14 031038asfaafsfsd](https://github.com/oss2024hnu/coursegraph-py/assets/82097844/15fdec9e-377b-48d7-bff8-262f3cf3121b)
![스크린샷 2024-05-14 031121asfasffsdaffsaf](https://github.com/oss2024hnu/coursegraph-py/assets/82097844/220ebbc2-844d-4123-ae89-e8b4ec1103a7)
