### PR TITLE
그래프 출력 시 뜨는 폰트 오류 해결

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -1,6 +1,7 @@
 import strictyaml
 import networkx as nx
 import matplotlib.pyplot as plt
+from matplotlib import rc
 import sys
 from fontutil import get_system_font
 
@@ -45,7 +46,7 @@ def adjust_ratio(ratio):
 
 def draw_course_structure(subjects, output_file):
     font_name = get_system_font()[0]['name']
-        
+    rc('font', family = font_name)
     G = nx.DiGraph()
     adjusted_pos = adjust_coordinates(subjects)
     plt.figure(figsize=(10,10)) # figure 사이즈 조정
@@ -65,8 +66,7 @@ def draw_course_structure(subjects, output_file):
         nx.draw(G, pos, with_labels=True, node_size=2000, node_color="skyblue",  font_family=font_name, font_size=10, font_weight="bold")
         for edge in G.edges():
             nx.draw_networkx_edges(G, pos, edgelist=[edge], arrowstyle='->', arrowsize=10)
-   
-    plt.rc('font', family=font_name)
+
     plt.title("과목 이수 체계도")
     plt.xlabel('학년')
     plt.ylabel('학기')


### PR DESCRIPTION
#270 
그래프 출력 시 나타나는 폰트 오류 문구가 뜨지 않도록 수정하여 해결하였습니다.