### PR TITLE
show_graph.py 함수에서 과목명이 노드를 벗어나는 이슈 해결

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -35,10 +35,6 @@ def read_subjects(filename: str) -> Optional[strictyaml.YAML]:
         print(f"YAML 데이터가 잘못되어있습니다: {e}", file=sys.stderr)
         return None
 
-def adjust_ratio(ratio):
-    circle = 400 * ratio
-    font = 1* ratio
-    return circle, font
 
 def adjust_coordinates(subjects: Optional[strictyaml.YAML]) -> Dict[Tuple[int, int], List[float]]:
     """
@@ -108,8 +104,7 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     edge_attrs = EdgeAttributes(edgelist=list(G.edges()))
     
     
-    nx.draw(G, pos, with_labels=True, node_size=0, node_color="skyblue", node_shape='s', font_family=font_name, font_size=10, font_weight="bold")
-
+    
      # 노드 라벨 그리기
     for node, (x, y) in pos.items():
         plt.text(x, y, node, fontsize=15, ha='center', va='center', 

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -84,7 +84,7 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     """
 
     font_name = get_system_font()[0]['name']
-    nodescale, fontscale = adjust_ratio(11) #@@@지우지 말아주세요 노드할때 사용해야합니다
+   # nodescale, fontscale = adjust_ratio(11) #@@@지우지 말아주세요 노드할때 사용해야합니다
     rc('font', family=font_name)
     G = nx.DiGraph()
     adjusted_pos = adjust_coordinates(subjects)
@@ -108,7 +108,13 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     edge_attrs = EdgeAttributes(edgelist=list(G.edges()))
     
     
-    nx.draw(G, pos, with_labels=True, node_size=nodescale, node_color="skyblue", font_family=font_name, font_size=fontscale, font_weight="bold")
+    nx.draw(G, pos, with_labels=True, node_size=0, node_color="skyblue", node_shape='s', font_family=font_name, font_size=10, font_weight="bold")
+
+     # 노드 라벨 그리기
+    for node, (x, y) in pos.items():
+        plt.text(x, y, node, fontsize=15, ha='center', va='center', 
+                 bbox=dict(facecolor='skyblue', edgecolor='black', boxstyle='round,pad=0.5'))
+        
     nx.draw_networkx_edges(G, pos, edgelist=edge_attrs.edgelist, arrowstyle=edge_attrs.arrowstyle, arrowsize=edge_attrs.arrowsize)
     
     plt.title("과목 이수 체계도")


### PR DESCRIPTION
 b05b11adf6fa64a2b9f1cf746e47a90debbf3671 버전을 기준으로 ai.yaml 을 input으로 show_graph.py 함수를 실행하면
다음과 같이 과목명이 노드를 벗어나는 이슈가 있습니다.
<img width="582" alt="이전버전" src="https://github.com/oss2024hnu/coursegraph-py/assets/62284856/bb1fdfe3-d8b9-479e-b64f-2dcca9cf108d">



![image](https://github.com/oss2024hnu/coursegraph-py/assets/62284856/cf1e66d1-2292-46cf-8cda-296999a66882)


상기 이슈를 해결하기 위해 위의 코드를  show_graph.py의 draw_course_structure 함수에 추가했습니다.
node_size를 0으로 설정하여 노드자체의 출력을 없애고 plt.text 함수를 추가하여 bbox 파라미터를 사용함으로써 과목명의 크기에 맞도록 사각형 형태의 박스가 같이 출력되게 하였습니다. 

그 결과 이러한 형태로 과목명이 출력됩니다. 
<img width="653" alt="최신버전" src="https://github.com/oss2024hnu/coursegraph-py/assets/62284856/f6236025-5f86-40c2-8e64-c29011e1792e">



 