### PR TITLE
#336 이슈 해결 CLI상에서 현재 출력 노드 좌표 데이터 출력

### DIFF
--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -49,10 +49,11 @@ def main():
         if output_format == 'graph':
             subjects = read_subjects(input_file)
             ref = draw_course_structure(subjects, output_file,width,height)
+            #노드좌표출력
             sorted_ref = dict(sorted(ref.items()))
             for key, value in sorted_ref.items():
                 print(f"{key}: {value}")
-                
+
         elif output_format == 'table':
             # kyahnu: 이 부분 --input 과 --output 을 활용하도록 일관된 인터페이스로 수정할 것
             data_processor = ShowTable(not show_mode, input_file, output_file,width,height)

--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -3,7 +3,7 @@ import sys
 
 import fontutil
 from show_table import ShowTable
-from show_graph import read_subjects, draw_course_structure
+from show_graph import read_subjects, draw_course_structure, cliprint
 
 
 def main():
@@ -50,9 +50,7 @@ def main():
             subjects = read_subjects(input_file)
             ref = draw_course_structure(subjects, output_file,width,height)
             #노드좌표출력
-            sorted_ref = dict(sorted(ref.items()))
-            for key, value in sorted_ref.items():
-                print(f"{key}: {value}")
+            cliprint(ref)
 
         elif output_format == 'table':
             # kyahnu: 이 부분 --input 과 --output 을 활용하도록 일관된 인터페이스로 수정할 것

--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -3,10 +3,11 @@ import sys
 
 import fontutil
 from show_table import ShowTable
-from show_graph import read_subjects, draw_course_structure
+from show_graph import read_subjects, draw_course_structure, cliprint
 
 
 def main():
+    
     try:
 
         parser = argparse.ArgumentParser(
@@ -47,7 +48,11 @@ def main():
             raise Exception("input file not specified")
         if output_format == 'graph':
             subjects = read_subjects(input_file)
-            draw_course_structure(subjects, output_file,width,height)
+            ref = draw_course_structure(subjects, output_file,width,height)
+            sorted_ref = dict(sorted(ref.items()))
+            for key, value in sorted_ref.items():
+                print(f"{key}: {value}")
+                
         elif output_format == 'table':
             # kyahnu: 이 부분 --input 과 --output 을 활용하도록 일관된 인터페이스로 수정할 것
             data_processor = ShowTable(not show_mode, input_file, output_file,width,height)

--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -3,7 +3,7 @@ import sys
 
 import fontutil
 from show_table import ShowTable
-from show_graph import read_subjects, draw_course_structure, cliprint
+from show_graph import read_subjects, draw_course_structure
 
 
 def main():

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -71,6 +71,10 @@ def adjust_coordinates(subjects: Optional[strictyaml.YAML]) -> Dict[Tuple[int, i
                 
     return adjusted_pos
 
+def cliprint(ref):
+    sorted_ref = dict(sorted(ref.items()))
+    for key, value in sorted_ref.items():
+        print(f"{key}: {value}")
 
 def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str, width: int, height: int):
     """

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -71,6 +71,14 @@ def adjust_coordinates(subjects: Optional[strictyaml.YAML]) -> Dict[Tuple[int, i
                 
     return adjusted_pos
 
+def clinput(x,y):
+    refarr =[x,y]
+    return refarr
+
+def cliprint(x,y):
+    refarr = clinput(x,y)
+    print(refarr[1][2])
+
 def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str, width: int, height: int):
     """
     파싱된 데이터를 기반으로, 과목의 위치를 조정하고, matplotlib로 데이터를 그린 후 output_file 경로로 파일을 저장하는 함수입니다.
@@ -89,13 +97,18 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     G = nx.DiGraph()
     adjusted_pos = adjust_coordinates(subjects)
     plt.figure(figsize=(width, height))  # 사용자가 지정한 이미지 크기로 설정
-
+    ref ={}
+    ind =0
     for subject in subjects:
         grade = int(subject['학년'])
-        #semester = int(subject['학기'])
+        # semester = int(subject['학기'])
         # x, y 좌표 조정
         x = grade
         y = adjusted_pos[grade].pop(0) # + semester : 학기간 간격을 주고싶다면 주석을 풀것.
+        ref[ind] = [(x,y)]
+        ind += 1
+        
+        # print(ref)
         G.add_node(subject['과목명'], pos=(x, y))
         if '선수과목' in subject:
             for prereq in subject['선수과목']:
@@ -130,3 +143,7 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
         plt.savefig(output_file)
     else:
         plt.show()
+    
+    
+    
+    return ref

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -71,13 +71,6 @@ def adjust_coordinates(subjects: Optional[strictyaml.YAML]) -> Dict[Tuple[int, i
                 
     return adjusted_pos
 
-def clinput(x,y):
-    refarr =[x,y]
-    return refarr
-
-def cliprint(x,y):
-    refarr = clinput(x,y)
-    print(refarr[1][2])
 
 def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str, width: int, height: int):
     """

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -59,7 +59,7 @@ def adjust_coordinates(subjects: Optional[strictyaml.YAML]) -> Dict[Tuple[int, i
             adjusted_pos[pos_key].append(0)
         else:
             adjusted_pos[pos_key] = [0]
-            
+
     for pos_key, positions in adjusted_pos.items():
         num_positions = len(positions)
         if num_positions > 1:
@@ -92,21 +92,22 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
 
     for subject in subjects:
         grade = int(subject['학년'])
-        semester = int(subject['학기'])
+        #semester = int(subject['학기'])
         # x, y 좌표 조정
         x = grade
-        y = semester*0.1 + adjusted_pos[grade].pop(0)
+        y = adjusted_pos[grade].pop(0) # + semester : 학기간 간격을 주고싶다면 주석을 풀것.
         G.add_node(subject['과목명'], pos=(x, y))
         if '선수과목' in subject:
             for prereq in subject['선수과목']:
                 G.add_edge(prereq, subject['과목명'])
 
-
+    
     pos = nx.get_node_attributes(G, 'pos')
 
     # 엣지 속성 설정
     edge_attrs = EdgeAttributes(edgelist=list(G.edges()))
-
+    
+    
     nx.draw(G, pos, with_labels=True, node_size=nodescale, node_color="skyblue", font_family=font_name, font_size=fontscale, font_weight="bold")
     nx.draw_networkx_edges(G, pos, edgelist=edge_attrs.edgelist, arrowstyle=edge_attrs.arrowstyle, arrowsize=edge_attrs.arrowsize)
     


### PR DESCRIPTION
#336이슈를 해결하였습니다. CLI창에서 노드들의 좌표데이터를 딕셔너리로 한데 묶어서 출력하는 기능을 추가하였습니다. 
0: [(1, -1.5)]
1: [(1, -0.8999999999999999)]
2: [(1, -0.3)]
3: [(1, 0.3)]
4: [(1, 0.8999999999999999)]
5: [(1, 1.5)]
6: [(2, -3.0)]
7: [(2, -2.4)]
8: [(2, -1.7999999999999998)]
9: [(2, -1.2)]
10: [(2, -0.6)]
11: [(2, 0.0)]
12: [(2, 0.6)]
... 이하 생략
키값은 노드번호를 의미하고
[(x,y)]으로 좌표의 위치를 알수 있습니다.
그래프 작업을 진행하면서 nx의 화면 출력방식이 특이하다고 느꼈는데 이 기능을 추가함으로써 실제 좌표와 화면 출력을 비교하며 좀 더 수월한 작업이 가능합니다.