### PR TITLE
CLI -i 인자의 일반 argument 변환 + 오타수정 작업

### DIFF
--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -16,10 +16,10 @@ def main():
         )
 
         # Adding command line options
-        parser.add_argument('-i', '--input', type=str, help='Specify the input YAML data file path. (required)')
+        parser.add_argument('input', type=str, help='Specify the input YAML data file path. (required)')
         parser.add_argument('-o', '--output', type=str, help='Specify the output image file path. (optional).')
         parser.add_argument('-f', '--format', choices=['graph', 'table'], default='graph',
-                            help='Sepcify the output format (graph, table). Defaults to graph.')
+                            help='Specify the output format (graph, table). Defaults to graph.')
         parser.add_argument('-s', '--size', type=str, help='Specify the size of the output image in format WIDTHxHEIGHT. (optional). Example: -s 800x600')
         args = parser.parse_args()
 


### PR DESCRIPTION
c626aa75ff088f71b4c11281969181057d8ebdd4
가장 최신 버전까지 두가지 이슈가 해결되지 않았습니다.

#325 이슈의 오타가 수정되지 않아 수정했습니다.

#195 기존의 i, input 옵션은 필수적임에도 옵션을 지정해줘야했습니다.
-> 옵션인자 제거를 통해 -i, --input 옵션을 사용하지 않아도 동작하도록 수정했습니다.

`parser.add_argument('input', type=str, help='Specify the input YAML data file path. (required)')`
        

다음부터는 
```
heoseungbin@Heo coursegraph-py % python3 coursegraph/__main__.py data/input.yaml   
```
이런식으로 작성하면 됩니다.

동작모습
<img width="628" alt="스크린샷 2024-06-04 16 06 11" src="https://github.com/oss2024hnu/coursegraph-py/assets/142968253/77012cbf-0243-4c0d-8b59-fec8e9e67077">
