### PR TITLE
v, verbose 옵션의 추가 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OUT_YAMLS=$(DATA_YAMLS:data%=$(OUTDIR)%)
 OUT_GRAPHS=$(OUT_YAMLS:%.yaml=%_G.png)
 OUT_TABLES=$(OUT_YAMLS:%.yaml=%_T.png)
 
-PYTHON=python
+PYTHON=python3
 CLICMD=$(PYTHON) coursegraph
 
 .PHONY: test delete
@@ -19,11 +19,14 @@ $(OUTDIR):
 	mkdir $(OUTDIR)
 
 $(OUTDIR)/%_G.png: ./data/%.yaml
-	$(CLICMD) -f graph $< -o $@
+	$(CLICMD) -f graph $< -o $@ 
+	$(CLICMD) -f graph $< -o $@ -v 1
+	$(CLICMD) -f graph $< -o $@ -v 2
 
 $(OUTDIR)/%_T.png: ./data/%.yaml
 	$(CLICMD) -f table $< -o $@
-
+	$(CLICMD) -f table $< -o $@ -v 1
+	$(CLICMD) -f table $< -o $@ -v 2
 # clean 타겟 정의
 clean_w:
 	rmdir /s /q $(OUTDIR)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OUT_YAMLS=$(DATA_YAMLS:data%=$(OUTDIR)%)
 OUT_GRAPHS=$(OUT_YAMLS:%.yaml=%_G.png)
 OUT_TABLES=$(OUT_YAMLS:%.yaml=%_T.png)
 
-PYTHON=python3
+PYTHON=python
 CLICMD=$(PYTHON) coursegraph
 
 .PHONY: test delete

--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -1,10 +1,24 @@
 import argparse
 import sys
+import logging
 
 import fontutil
 from show_table import ShowTable
 from show_graph import read_subjects, draw_course_structure, cliprint
 
+def verbose_0():
+    logging.warning('Verbose level 0')
+def verbose_1(width, height, input_file, output_file):
+    logging.info('Verbose level 1 : Summary Information')
+    print('width * height :', width, '*', height)
+    print(f"The input YAML file path has been specified: {input_file}")
+    print(f"The output image file path has been specified: {output_file}")
+def verbose_2(width, height, input_file, output_file):
+    logging.debug('Verbose level 2 : Detailed Developer Information')
+    print('width * height :', width, '*', height)
+    print(f"The input YAML file path has been specified: {input_file}")
+    print(f"The output image file path has been specified: {output_file}")
+    
 
 def main():
     
@@ -21,6 +35,12 @@ def main():
         parser.add_argument('-f', '--format', choices=['graph', 'table'], default='graph',
                             help='Specify the output format (graph, table). Defaults to graph.')
         parser.add_argument('-s', '--size', type=str, help='Specify the size of the output image in format WIDTHxHEIGHT. (optional). Example: -s 800x600')
+        parser.add_argument('-v', '--verbose', type=int, choices = [0, 1, 2],
+                            default = 0, 
+                            help = 'Set the verbose level (optional)\n'
+                            '0 - Minium output, option for end user\n'
+                            '1 - Standard output, informational message\n'
+                            '2 - Debug output, detailed information')
         args = parser.parse_args()
 
         # Accessing the command line options
@@ -36,22 +56,32 @@ def main():
             # Default size
             width, height = 20,10
 
-        if output_file:
-            print(f"The output image file path has been specified: {output_file}")
-        else:
-            show_mode = True
-
         if input_file:
-            print(f"The input YAML file path has been specified: {input_file}")
+            pass
         else:
             parser.print_help(sys.stderr)
             raise Exception("input file not specified")
+
+        if output_file:
+            pass
+        else:
+            show_mode = True
+
+        if args.verbose == 0: # 일반사용자를 위해 아무것도 출력하지 않음
+            logging.basicConfig(level = logging.WARNING)
+            verbose_0()
+        elif args.verbose == 1: # 요약된 정보 출력
+            logging.basicConfig(level = logging.INFO)
+            verbose_1(width, height, input_file, output_file)
+        elif args.verbose == 2: # 상세 정보 출력
+            logging.basicConfig(level = logging.DEBUG)
+            verbose_2(width, height, input_file, output_file)
+        
         if output_format == 'graph':
             subjects = read_subjects(input_file)
-            ref = draw_course_structure(subjects, output_file,width,height)
-            #노드좌표출력
-            cliprint(ref)
-
+            ref = draw_course_structure(subjects, output_file, width, height)
+            if args.verbose == 2:
+                cliprint(ref)
         elif output_format == 'table':
             # kyahnu: 이 부분 --input 과 --output 을 활용하도록 일관된 인터페이스로 수정할 것
             data_processor = ShowTable(not show_mode, input_file, output_file,width,height)


### PR DESCRIPTION
#364 
1. verbose 옵션이 정해지지 않은 경우 -> verbose = 0 -> 일반 사용자를 위해 출력 X
```
heoseungbin@Heo coursegraph-py % python3 coursegraph data/input.yaml 
```
```
WARNING:root:Verbose level 0
```
2. verbose = 1 인경우 축약된 정보만을 출력
```
heoseungbin@Heo coursegraph-py % python3 coursegraph data/input.yaml -v 1
```
```
INFO:root:Verbose level 1 : Summary Information
width * height : 20 * 10
The input YAML file path has been specified: data/input.yaml
The output image file path has been specified: None
```
3. verbose = 2 인경우 개발자를 위한 노드 위치 정보 + 디버그 로그 정보 출력
```
heoseungbin@Heo coursegraph-py % python3 coursegraph data/input.yaml -v 2
```
```
DEBUG:root:Verbose level 2 : Detailed Developer Information
width * height : 20 * 10
The input YAML file path has been specified: data/input.yaml
The output image file path has been specified: None
DEBUG:matplotlib.font_manager:findfont: score(FontEntry(fname='/System/Library/Fonts/SFNSItalic.ttf', name='System Font', style='italic', variant='normal', weight=400, stretch='normal', size='scalable')) = 11.335
DEBUG:matplotlib.font_manager:findfont: score(FontEntry(fname='/System/Library/Fonts/Supplemental/Al Nile.ttc', name='Al Nile', style='normal', variant='normal', weight=400, stretch='normal', size='scalable')) = 10.335
DEBUG:matplotlib.font_manager:findfont: score(FontEntry(fname='/System/Library/Fonts/Supplemental/Georgia Italic.ttf', name='Georgia', style='italic', variant='normal', weight=400, stretch='normal', size='scalable')) = 11.335
DEBUG:matplotlib.font_manager:findfont: Matching Apple SD Gothic Neo:style=normal:variant=normal:weight=bold:stretch=normal:size=18.0 to Apple SD Gothic Neo ('/System/Library/Fonts/AppleSDGothicNeo.ttc') with score of 0.335000.
0: [(1, 0.5)]
1: [(1, 1.0)]
2: [(1, 1.5)]
3: [(2, 0.5)]
4: [(2, 1.0)]
5: [(3, 0.5)]
6: [(3, 1.0)]
7: [(4, 0.5)]
8: [(4, 1.0)]
```

make file 또한 verbose 옵션이 0, 1, 2 에 따른 모든 옵션 테스트가 가능하게 수정이 되어 총 30번의 출력 과정을 진행합니다