### PR TITLE
학기 노드와 중앙 실선 추가

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -152,6 +152,19 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
         bbox_props = dict(boxstyle=f"round,pad=0.5", ec='black', lw=2, facecolor='white')
         plt.text(x, y, f"{grade}학년", fontsize=18, ha='center', va='center', fontweight='bold', bbox=bbox_props)
 
+    # 학기 노드 추가
+    max_x = max([x for x, y in pos.values()]) + 0.3  # x 좌표의 최대값
+    semester_positions = [1.5, 4.5] # 각 학기의 y 좌표 
+    for semester in range(1, 3):  # 1학기, 2학기
+        G.add_node(f"{semester}학기", pos=(max_x - 4.15, semester_positions[semester-1]))
+
+    pos = nx.get_node_attributes(G, 'pos')
+
+    for semester in range(1, 3):  # 1학기, 2학기
+        x, y = pos[f"{semester}학기"]
+        bbox_props = dict(boxstyle=f"round,pad=0.5", ec='black', lw=2, facecolor='white')
+        plt.text(x, y, f"{semester}학기", fontsize=18, ha='center', va='center', fontweight='bold', bbox=bbox_props)
+
     nx.draw_networkx_edges(G, pos, edgelist=edge_attrs.edgelist,
                            arrowstyle=edge_attrs.arrowstyle,
                            arrowsize=edge_attrs.arrowsize)
@@ -163,6 +176,11 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     plt.yticks(range(1, 3))  # 학기
     plt.gca().invert_yaxis()
     plt.grid(True)  # 그리드 표시
+
+    min_y = min(y for _, y in pos.values())
+    max_y = max(y for _, y in pos.values())
+    center_y = (min_y + max_y) / 1.75
+    plt.axhline(center_y, color='black', linestyle='-', linewidth=2)
 
     # 학년별로 배경색 설정
     for grade in range(1, 5):


### PR DESCRIPTION
#368 이슈에서와 같이 학기와 중앙선에 대해 언급한 내용을 바탕으로 학기 노드와 중앙선을 추가하였습니다.
![학년 노드](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/4b1fbaa2-eb27-4e78-8bc4-ea2a222a4cce)
↑ [8b84173](https://github.com/oss2024hnu/coursegraph-py/commit/8b8417387ccc93b9da2d551461ca104cee6e9020)버전의 학년 노드만 있는 그래프에서
![학기노드](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/6369732e-3265-4ac8-bf50-c650f765c9f4) 학기와 중앙선을 추가했습니다. 중앙선과 학기를 바탕으로 노드를 배치하면 될 것 같습니다.