### PR TITLE
#383이슈 해결

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -63,7 +63,7 @@ def adjust_coordinates(subjects: Optional[strictyaml.YAML]) -> Dict[Tuple[int, i
     for pos_key, positions in adjusted_pos.items():
         num_positions = len(positions)
         if num_positions > 0:
-            spacing = 0.5
+            spacing = 0.3
             init = 0
 
             for i in range(num_positions):
@@ -137,6 +137,7 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
         plt.text(x, y, node, fontsize=15, ha='center', va='center',
                  bbox=dict(facecolor='white', edgecolor=get_edge_color(subject['구분']), boxstyle='round,pad=0.5',
                            linewidth=3))
+######
 
     # 학년 노드 추가
     non_empty_positions = [max(y_values) for y_values in adjusted_pos.values() if y_values]
@@ -151,14 +152,17 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
         x, y = pos[f"{grade}학년"]
         bbox_props = dict(boxstyle=f"round,pad=0.5", ec='black', lw=2, facecolor='white')
         plt.text(x, y, f"{grade}학년", fontsize=18, ha='center', va='center', fontweight='bold', bbox=bbox_props)
-
+######
     nx.draw_networkx_edges(G, pos, edgelist=edge_attrs.edgelist,
                            arrowstyle=edge_attrs.arrowstyle,
                            arrowsize=edge_attrs.arrowsize)
-
+    
+    
     plt.title("과목 이수 체계도")
     plt.xlabel('학년')
     plt.ylabel('학기')
+    #그래프상하좌우여백
+    plt.subplots_adjust(left=0.03,bottom=0.07,right=0.98,top=0.95)
     plt.xticks(range(1, 5))  # 학년
     plt.yticks(range(1, 3))  # 학기
     plt.gca().invert_yaxis()


### PR DESCRIPTION
그래프여백을 조정했습니다.
그래프여백을 조정한 기준 -s 스케일은 default입니다.
그래프여백조정코드를 만지실 분들을 위하여 드리는 말씀 : 조정코드는 전체화면 비율로 작동합니다. 
plt.subplots_adjust(left=0.03,bottom=0.07,right=0.98,top=0.95)
이런식으로 작동하는데, right > left를 지켜주셔야 합니다. 0~1의 값으로 제어됩니다.
ex) 왼쪽은 띄우고싶은 비율을 적으면 되지만, 그 반대편인 오른쪽은 1에서 그 값을 빼주시면 되겠습니다.
ps) 학년 노드가 안보인다 하실 수도 있는데 이것도 구동방식을 손을 봐서 올리겠습니다 현재는 비율에 밀려 안보이지만 존재합니다.
![test](https://github.com/oss2024hnu/coursegraph-py/assets/162536366/534d422c-d6d2-4811-913f-35cfc3cb727a)
