### PR TITLE
Makefile 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-# PNG 파일을 보관할 디렉터리 변수 이름
+# PYTHON 변수 설정
+PYTHON=$(shell where python || where python3)
+CLICMD=$(PYTHON) coursegraph
+
 OUTDIR:=out
 
 DATA_YAMLS=$(wildcard data/*.yaml)
@@ -8,28 +11,25 @@ OUT_DOTS=$(OUT_YAMLS:%.yaml=%_G.dot)
 OUT_GRAPHS=$(OUT_YAMLS:%.yaml=%_G.png)
 OUT_TABLES=$(OUT_YAMLS:%.yaml=%_T.png)
 
-PYTHON=python
-CLICMD=$(PYTHON) coursegraph
-
-.PHONY: test delete
+.PHONY: test delete clean_w clean_m
 
 # test 타겟 정의
-test: $(OUTDIR) $(OUT_DOTS) $(OUT_GRAPHS) $(OUT_TABLES)
+test: $(OUTDIR) $(OUT_GRAPHS) $(OUT_TABLES)
+#test: $(OUTDIR) $(OUT_DOTS) $(OUT_GRAPHS) $(OUT_TABLES)
 
 $(OUTDIR):
 	mkdir $(OUTDIR)
 
-$(OUTDIR)/%_G.dot: ./data/%.yaml
-	$(CLICMD) -f dot $< -o $@ 
-	# $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
-	# $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
-	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
+#$(OUTDIR)/%_G.dot: ./data/%.yaml
+#	$(CLICMD) -f dot $< -o $@ 
+#	# $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
+#	# $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
+#	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
 
 $(OUTDIR)/%_G.png: ./data/%.yaml
 	$(CLICMD) -f graph $< -o $@ 
 	$(CLICMD) -f graph $< -o $@ -v 1
 	$(CLICMD) -f graph $< -o $@ -v 2
-
 
 $(OUTDIR)/%_T.png: ./data/%.yaml
 	$(CLICMD) -f table $< -o $@

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ onboarding 디렉토리의 문서들을 참고해 주세요
 3. Codespace 실행 후 정상적으로 작동하는지 확인
     'python coursegraph data/input.yaml -o out.png' 명령어 실행
 
+## Makefile 실행 방법
+1. https://jstar0525.tistory.com/264 이 사이트에 들어가서 make 명령어를 설치하라는 대로 설치한다(설치할 때 주소를 복사해놓기).
+2. 윈도우 검색에서 시스템 환경 변수 설정에 들어가 환경변수의 path에 설치할 때 주소를 저장한다.
+3. cmd 창에서 'make-v' 명령어를 수행한다.
+
+수행 명령어 = make test
+(윈도우 버전)삭제 명령어 = make clean_w
+(Mac, Linux버전)삭제 명령어 = make clean_m
+
 ### CLI 사용법
 다음과 같이 `coursegraph/__main__.py`를 파이썬으로 실행시켜 활용한다.
 ```


### PR DESCRIPTION
#374 의 
```
PYTHON=$(shell where python || where python3)
CLICMD=$(PYTHON) coursegraph
```
python, python3을 구분하는 코드를 기입하여 자동으로 시스템에서 사용 가능한 python이나 python3을 찾아서 사용할 수 있게 해줍니다. 따라서 make test 명령어를 실행할 때, PYTHON 변수가 자동으로 적절한 파이썬 명령어(python 또는 python3)로 설정됩니다. 
단, window에서는 where을 사용해야하고 Unix환경인 Mac에서는 which를 사용해야합니다.

그리고 현재 Makefile이 실행이 되지 않아 찾아본 결과 23번 줄인 G.dot 명령어에 문제가 발생하는 것 같아 주석처리하고 실행해봤습니다.
```
#$(OUTDIR)/%_G.dot: ./data/%.yaml
#	$(CLICMD) -f dot $< -o $@ 
#	# $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
#	# $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
#	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
```
그 결과, 다른 Makefile은 잘 작동이 되는 것을 확인해보았습니다.

![makefile 작동](https://github.com/oss2024hnu/coursegraph-py/assets/162093700/c5424975-01ba-405c-98ef-1ab2e3086046)
