### PR TITLE
#413이슈 해결 : 학기 구분줄코드 정리 (오작동 없애기)

### DIFF
--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -7,6 +7,8 @@ from show_table import ShowTable
 from show_graph import read_subjects, draw_course_structure, cliprint
 from show_dot import print_dot
 
+
+
 def verbose_0():
     logging.warning('Verbose level 0')
 def verbose_1(width, height, input_file, output_file):
@@ -90,6 +92,7 @@ def main():
         elif output_format == 'dot':
             subjects = read_subjects(input_file)
             print_dot(subjects, output_file)
+                        
             # raise Exception(f"cannot handle output format {output_format}") # 아직 dot 파일 형식에 대한 내용 없음
         elif output_format in ['table', 'pdf']:
             data_processor = ShowTable(not show_mode, input_file, output_file, width, height)

--- a/coursegraph/show_dot.py
+++ b/coursegraph/show_dot.py
@@ -59,7 +59,7 @@ def print_dot(subjects: strictyaml.YAML, output_file: Optional[str]) -> None:
     if output_file is None:
         graph.dot()
     else:
-        with open(output_file, "w") as outfile:
+        with open(output_file, "w", encoding= "utf-8") as outfile:
             graph.dot(outfile)
 
  

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -186,10 +186,8 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     plt.gca().invert_yaxis()
     plt.grid(True)  # 그리드 표시
 
-    min_y = min(y for _, y in pos.values())
-    max_y = max(y for _, y in pos.values())
-    center_y = (min_y + max_y) / 1.75
-    plt.axhline(center_y, color='black', linestyle='-', linewidth=2)
+    
+    plt.axhline(2, color='black', linestyle='-', linewidth=2)
 
     # 학년별로 배경색 설정
     for grade in range(1, 5):


### PR DESCRIPTION

![캡처2](https://github.com/oss2024hnu/coursegraph-py/assets/162536366/d1fc340e-5a52-4d56-8c7d-4956d21be1cd)


min_y = min(y for _, y in pos.values())
    max_y = max(y for _, y in pos.values())
    center_y = (min_y + max_y) /2
삭제
plt.axhline(center_y, color='black', linestyle='-', linewidth=2)
->
plt.axhline(2, color='black', linestyle='-', linewidth=2)
수정
기존의 불필요하였고 오작동을 유발하였던 수식부분을 제거하고 , plt.axhline의 쓰임새대로 비율 2를 적어넣어서 배경 그리드에서 절반을 나누게 오작동변수를 줄였습니다. 이제 직선이 제대로 그리드를 절반으로 나눕니다.