### PR TITLE
Makefile 수정본

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-# PNG 파일을 보관할 디렉터리 변수 이름
+# PYTHON 변수 설정
+PYTHON=$(shell where python || where python3)
+CLICMD=$(PYTHON) coursegraph
+
 OUTDIR:=out
 
 DATA_YAMLS=$(wildcard data/*.yaml)
@@ -8,28 +11,25 @@ OUT_DOTS=$(OUT_YAMLS:%.yaml=%_G.dot)
 OUT_GRAPHS=$(OUT_YAMLS:%.yaml=%_G.png)
 OUT_TABLES=$(OUT_YAMLS:%.yaml=%_T.png)
 
-PYTHON=python
-CLICMD=$(PYTHON) coursegraph
-
-.PHONY: test delete
+.PHONY: test delete clean_w clean_m
 
 # test 타겟 정의
-test: $(OUTDIR) $(OUT_DOTS) $(OUT_GRAPHS) $(OUT_TABLES)
+test: $(OUTDIR) $(OUT_GRAPHS) $(OUT_TABLES)
+#test: $(OUTDIR) $(OUT_DOTS) $(OUT_GRAPHS) $(OUT_TABLES)
 
 $(OUTDIR):
 	mkdir $(OUTDIR)
 
-$(OUTDIR)/%_G.dot: ./data/%.yaml
-	$(CLICMD) -f dot $< -o $@ 
-	# $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
-	# $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
-	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
+#$(OUTDIR)/%_G.dot: ./data/%.yaml
+#	$(CLICMD) -f dot $< -o $@ 
+#	# $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
+#	# $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
+#	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
 
 $(OUTDIR)/%_G.png: ./data/%.yaml
 	$(CLICMD) -f graph $< -o $@ 
 	$(CLICMD) -f graph $< -o $@ -v 1
 	$(CLICMD) -f graph $< -o $@ -v 2
-
 
 $(OUTDIR)/%_T.png: ./data/%.yaml
 	$(CLICMD) -f table $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # PYTHON 변수 설정
-PYTHON=$(shell where python || where python3)
+ifeq ($(OS), Windows_NT)
+    PYTHON=$(shell where python || where python3)
+else
+    PYTHON=$(shell which python || which python3)
+endif
 CLICMD=$(PYTHON) coursegraph
 
 OUTDIR:=out
@@ -22,8 +26,8 @@ $(OUTDIR):
 
 #$(OUTDIR)/%_G.dot: ./data/%.yaml
 #	$(CLICMD) -f dot $< -o $@ 
-#	# $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
-#	# $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
+#	 $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
+#	 $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
 #	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
 
 $(OUTDIR)/%_G.png: ./data/%.yaml

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ OUT_TABLES=$(OUT_YAMLS:%.yaml=%_T.png)
 .PHONY: test delete clean_w clean_m
 
 # test 타겟 정의
-test: $(OUTDIR) $(OUT_GRAPHS) $(OUT_TABLES)
-#test: $(OUTDIR) $(OUT_DOTS) $(OUT_GRAPHS) $(OUT_TABLES)
+test: $(OUTDIR) $(OUT_DOTS) $(OUT_GRAPHS) $(OUT_TABLES)
 
 $(OUTDIR):
 	mkdir $(OUTDIR)

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ test: $(OUTDIR) $(OUT_GRAPHS) $(OUT_TABLES)
 $(OUTDIR):
 	mkdir $(OUTDIR)
 
-#$(OUTDIR)/%_G.dot: ./data/%.yaml
-#	$(CLICMD) -f dot $< -o $@ 
+$(OUTDIR)/%_G.dot: ./data/%.yaml
+	$(CLICMD) -f dot $< -o $@ 
 #	 $(CLICMD) -f dot $< -o $@ -v 1 # 아직 dot에는 verbose level 적용안됨
 #	 $(CLICMD) -f dot $< -o $@ -v 2 # 아직 dot에는 verbose level 적용안됨
-#	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
+	- dot -Tsvg -O $@  # graphviz dot 유틸리티로 svg생성 (실패해도 넘어감)
 
 $(OUTDIR)/%_G.png: ./data/%.yaml
 	$(CLICMD) -f graph $< -o $@ 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ onboarding 디렉토리의 문서들을 참고해 주세요
 3. Codespace 실행 후 정상적으로 작동하는지 확인
     'python coursegraph data/input.yaml -o out.png' 명령어 실행
 
+## Makefile 실행 방법
+1. https://jstar0525.tistory.com/264 이 사이트에 들어가서 make 명령어를 설치하라는 대로 설치한다(설치할 때 주소를 복사해놓기).
+2. 윈도우 검색에서 시스템 환경 변수 설정에 들어가 환경변수의 path에 설치할 때 주소를 저장한다.
+3. cmd 창에서 'make-v' 명령어를 수행한다.
+
+수행 명령어 = make test
+(윈도우 버전)삭제 명령어 = make clean_w
+(Mac, Linux버전)삭제 명령어 = make clean_m
+
 ### CLI 사용법
 다음과 같이 `coursegraph/__main__.py`를 파이썬으로 실행시켜 활용한다.
 ```


### PR DESCRIPTION
#374  의
```
# PYTHON 변수 설정
ifeq ($(OS), Windows_NT)
    PYTHON=$(shell where python || where python3)
else
    PYTHON=$(shell which python || which python3)
endif
CLICMD=$(PYTHON) coursegraph
```
python, python3을 구분하는 코드를 기입하여 운영체제가 window인지 아닌지로 python이나 python3으로 나눠 사용할 수 있게 해줍니다. 따라서 make test 명령어를 실행할 때, PYTHON 변수가 자동으로 적절한 파이썬 명령어(python 또는 python3)로 설정됩니다.

그리고 #417  에서 graphviz 패키지를 설치하여 사용해보니 다시 정상 작동이 되는 것을 확인해보았습니다.

Makefile 최종 수정본 6d6363b4e851d0247a8bb3fd3b4b68a1e28adea9 이 파일을 머지하시면 될 것 같습니다.