### PR TITLE
유효한 파일 입력할 때까지 사용자 입력 반복

### DIFF
--- a/coursegraph/schema_checker.py
+++ b/coursegraph/schema_checker.py
@@ -78,8 +78,13 @@ def validate_yaml(file_path : str):
 
 
 def main():
-    file_path = input("파일명을 입력해주세요: ")
-    validate_yaml(file_path)
+    while True:
+    file_path = input("파일명을 입력해주세요: ").strip()
+    try:
+        validate_yaml(file_path)
+        break  # 유효성 검사 통과 시 반복문 종료
+    except ValueError:
+        continue  # 유효하지 않은 입력이면 다시 입력 받음
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
사용자가 유효한 파일명을 입력할 때까지 반복적으로 요구하며, validate_yaml 함수를 사용하여 파일의 유효성을 검사합니다. 만약 입력된 파일명이 유효하지 않으면, ValueError가 발생하고 다시 입력을 요구합니다. 유효한 파일명이 입력되면 반복문이 종료됩니다.