### PR TITLE
#430이슈 해결 dot파일 생성시 한글 깨짐현상 수리

### DIFF
--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -7,6 +7,8 @@ from show_table import ShowTable
 from show_graph import read_subjects, draw_course_structure, cliprint
 from show_dot import print_dot
 
+
+
 def verbose_0():
     logging.warning('Verbose level 0')
 def verbose_1(width, height, input_file, output_file):
@@ -90,6 +92,7 @@ def main():
         elif output_format == 'dot':
             subjects = read_subjects(input_file)
             print_dot(subjects, output_file)
+                        
             # raise Exception(f"cannot handle output format {output_format}") # 아직 dot 파일 형식에 대한 내용 없음
         elif output_format in ['table', 'pdf']:
             data_processor = ShowTable(not show_mode, input_file, output_file, width, height)

--- a/coursegraph/show_dot.py
+++ b/coursegraph/show_dot.py
@@ -59,7 +59,7 @@ def print_dot(subjects: strictyaml.YAML, output_file: Optional[str]) -> None:
     if output_file is None:
         graph.dot()
     else:
-        with open(output_file, "w") as outfile:
+        with open(output_file, "w", encoding= "utf-8") as outfile:
             graph.dot(outfile)
 
  

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -186,10 +186,8 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     plt.gca().invert_yaxis()
     plt.grid(True)  # 그리드 표시
 
-    min_y = min(y for _, y in pos.values())
-    max_y = max(y for _, y in pos.values())
-    center_y = (min_y + max_y) / 1.75
-    plt.axhline(center_y, color='black', linestyle='-', linewidth=2)
+    
+    plt.axhline(2, color='black', linestyle='-', linewidth=2)
 
     # 학년별로 배경색 설정
     for grade in range(1, 5):


### PR DESCRIPTION
#430 show_graph에서는 subject파일을 잘 만들어서 show_dot에 보내었지만 정작 show_dot함수에서 dot파일을 출력할 때 인코딩 조건을 적지 않고 출력한다는 사실을 발견하고 수정하였습니다. 이로써 dot 파일안에서 한글(한글로 된 과목이름들)이 제대로 출력됩니다.
/* Generated by GvGen v.1.0 (https://www.github.com/stricaud/gvgen) */

digraph G {
rankdir=TB;ranksep=1.25;
   subgraph cluster1 {
   label="1-1";
      node47 [shape="note",label="프로그래밍실습"];
      node48 [shape="note",label="이산구조"];
      node49 [shape="note",label="컴퓨터개론"];
      node50 [shape="note",label="웹스크립트프로그래밍"];
      node51 [shape="note",label="디지털공학"];
      node52 [color="green",style="dashed",label=""];
   }
   subgraph cluster8 {
   label="4-2";
      node9 [shape="note",label="데이터마이닝"];
      node10 [shape="note",label="빅데이터"];
      node11 [shape="note",label="머신러닝의이해"];
      node12 [shape="note",label="프로젝트관리"];
      node13 [shape="note",label="양자컴퓨팅"];
      node59 [color="green",style="dashed",label=""];
   }
   subgraph cluster7 {
   label="4-1";
      node14 [shape="note",label="웹서버프로그래밍"];
      node15 [shape="note",label="게임서버프로그래밍"];
      node16 [shape="note",label="가상증강현실"];
      node17 [shape="note",label="데이터베이스프로그래밍"];
      node18 [shape="note",label="블록체인"];