### PR TITLE
README.md dot 사용법 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,19 @@ OUT_DOTS=$(OUT_YAMLS:%.yaml=%_G.dot)
 OUT_GRAPHS=$(OUT_YAMLS:%.yaml=%_G.png)
 OUT_TABLES=$(OUT_YAMLS:%.yaml=%_T.png)
 
-PYTHON=python
+PYTHON := $(shell \
+  if command -v python3 > /dev/null 2>&1; then \
+    echo python3; \
+  elif command -v python > /dev/null 2>&1; then \
+    echo python; \
+  elif where python3 > nul 2>&1; then \
+    echo python3; \
+  elif where python > nul 2>&1; then \
+    echo python; \
+  else \
+    echo ""; \
+  fi \
+)
 CLICMD=$(PYTHON) coursegraph
 
 .PHONY: test delete

--- a/README.md
+++ b/README.md
@@ -47,11 +47,27 @@ Enjoy using the CLI utility!
 - `-f graph` 혹은 `--format graph` 옵션을 제공하면 이수체계도를 방향그래프 형태로 보여줌.
   `-f` 혹은 `--foramt` 옵션을 제공하지 않은 경우도 graph 모드로 동작.
 - `-f table` 혹은 `--format table` 옵션을 주었을 경우, yaml 파일의 전체 내용을 한꺼번에 보기 좋은 표의 형태로 보여준다.
+- `-f dot` 혹은 `--format dot` 옵션을 주었을 경우, yaml 파일의 내용을 .dot 형태로 보여준다.
 - '-s WIDTH,HEIGHT' 혹은 '--size WIDTH,HEIGHT' 옵션을 제공했을 경우 이미지의 크기를 가로,세로의 입력값으로 지정해준다.
   '-s' 혹은 '--size' 옵션을 제공하지 않은 경우에는 이미지의 크기는 10,20 으로 지정된다. 
   `-v {0,1,2}` 혹은 `--verbose {0,1,2}` 옵션을 제공했을 경우 출력되는 정보의 상세 수준을 지정한다. 0은 최소한의 출력, 1은 요약 정보, 2는 상세 디버그 정보를 출력한다.
   '-v' 혹은 '--verbose' 옵션을 제공하지 않는 경우에는 최소한의 출력으로 보여준다.
 
+### -f dot 사용법
+```
+python coursegraph data/input.yaml -f dot -o out.dot
+```
+출력된 .dot 파일 또는 .svg 파일을 
+http://magjac.com/graphviz-visual-editor/
+해당 사이트와 같은 graphviz 시각화 사이트에 입력
+
+- using graphviz software (권장하지 않음)
+해당사이트 참조 본인 운영체제에 알맞은 방식으로 graphviz 설치
+https://www.graphviz.org/download/ 
+
+```
+% dot -Tpng [dot 파일 이름].dot > [출력할 파일 이미지의 이름].png
+```
 ### GUI 사용법
 coursegraph-py/coursegraph로 이동한 다음 'python gui.py'를 터미널에 넣고 실행하면 gui화면이 나온다.
 현재 사용가능한 기능은 파일 열기, 다른이름으로 저장하기, 연 이미지를 초기화 시키는 기능이 있다.


### PR DESCRIPTION
#405 해당 이슈에 맞추어
dot 옵션이 추가된 것에 대해 README.md 파일 수정이 이루어지지 않아 
dot 옵션 사용법에 대한 내용을 추가했습니다.

graphviz 를 설치하는 부분은 권장하지 않는 옵션으로 표현했고
다른 옵션과 달리 dot 옵션에는 추가적인 설명이 덧붙으면 좋을 것 같아
graphivz 시각화에 필요한 웹사이트를 추가함으로써 사용자들이 쉽게 접근할 수 있도록 추가했습니다.

현재 PR 요청된 파일의 README.md 파일은 .dot 옵션에 관한 것이 아니라 판단했기에 다시 작성했습니다