### PR TITLE
show_table.py에 appltmap을 활용하여 더 효율적인 벡터화 된 연산 사용

### DIFF
--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -80,36 +80,37 @@ class ShowTable:
         dpi = 100
         return dpi
 
-    def make_data(self, data, width, height):
-        """
-        데이터로부터 테이블을 생성하거나 이미지를 저장한다.
+def make_data(self, data, width, height):
+    """
+    데이터로부터 테이블을 생성하거나 이미지를 저장한다.
 
-        Args:
-            data: 테이블 생성의 데이터, '과목' 키가 포함되어야함
-            width: 생성될 테이블의 너비 
-            height: 생성될 테이블의 높이
-        """
-        font_name = font_manager.FontProperties(fname=self.font_path).get_name()
-        rc('font', family=font_name)
-        if '과목' in data:
-            df = pd.DataFrame(data['과목'])
-            # NaN 값을 빈 문자열로 대체
-            df.fillna('', inplace=True)
-            # DataFrame을 스택 형태로 변환하여 각 셀을 변환
-            df = df.stack().map(lambda x: ', '.join(map(str, x)) if isinstance(x, list) else x).unstack()
-            res = self.dpi_ratio(width, height)
-            fig, ax = plt.subplots(figsize=(width, height), dpi=res)
-            ax.axis('off')
-            ax.table(cellText=df.values, colLabels=df.columns, cellLoc='center', loc='center', colWidths=[0.2] * len(df.columns))
-            ax.set_title('과목 표')
-            plt.tight_layout()
-            if self.image_mode:
-                if self.output_filename:
-                    plt.savefig(self.output_filename)
-            else:
-                plt.show()
+    Args:
+        data: 테이블 생성의 데이터, '과목' 키가 포함되어야 함
+        width: 생성될 테이블의 너비
+        height: 생성될 테이블의 높이
+    """
+    font_name = font_manager.FontProperties(fname=self.font_path).get_name()
+    rc('font', family=font_name)
+    if '과목' in data:
+        df = pd.DataFrame(data['과목'])
+        # NaN 값을 빈 문자열로 대체
+        df.fillna('', inplace=True)
+        # DataFrame의 각 셀에 함수 적용, 리스트를 문자열로 변환
+        df = df.applymap(lambda x: ', '.join(map(str, x)) if isinstance(x, list) else x)
+        res = self.dpi_ratio(width, height)
+        fig, ax = plt.subplots(figsize=(width, height), dpi=res)
+        ax.axis('off')
+        ax.table(cellText=df.values, colLabels=df.columns, cellLoc='center', loc='center', colWidths=[0.2] * len(df.columns))
+        ax.set_title('과목 표')
+        plt.tight_layout()
+        if self.image_mode:
+            if self.output_filename:
+                plt.savefig(self.output_filename)
         else:
-            print("데이터에 '과목' 정보가 없습니다.") 
+            plt.show()
+    else:
+        print("데이터에 '과목' 정보가 없습니다.")
+ 
             
     def create_pdf(self, df):
         c = canvas.Canvas(self.output_filename, pagesize=letter)


### PR DESCRIPTION
#407 

make_data 메서드 내에서 DataFrame의 각 원소를 처리할 때 map 함수 대신 applymap 함수를 사용하여 성능을 개선하고 코드의 가독성을 향상시킬 수 있습니다. applymap 함수는 DataFrame의 각 셀에 대해 주어진 함수를 적용하므로, 전체 DataFrame에 대한 변환을 보다 효율적으로 수행할 수 있습니다.

변경된 점
df.stack().map(...).unstack() 방식을 df.applymap(...)로 변경했습니다. applymap은 DataFrame의 모든 원소에 대해 주어진 함수를 적용합니다. 이 경우, 리스트 타입의 데이터가 문자열로 변환될 수 있도록 처리하고 있습니다.