### PR TITLE
show_table.py canvas에 대한 모듈 누락 추가

### DIFF
--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -6,6 +6,8 @@ import platform
 import matplotlib.pyplot as plt
 from fontutil import get_system_font
 from matplotlib import font_manager, rc
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
 
 
 class ShowTable:


### PR DESCRIPTION
from reportlab.pdfgen import canvas
from reportlab.lib.pagesizes import letter

canvas를 사용하기 위하여 모듈을 추가 했습니다.