### PR TITLE
유효성 검사 함수 확장

### DIFF
--- a/coursegraph/schema_checker.py
+++ b/coursegraph/schema_checker.py
@@ -1,11 +1,9 @@
 import re
-import sys
-import strictyaml
-from strictyaml import EmptyList
+from typing import Union, List
 
 
 # 과목명,트랙,마이크로디그리,선수과목에는 문자만 사용되었는지 확인하는 함수
-def validate_string_or_sequence(value : str) -> str:
+def validate_string_or_sequence(value: Union[str, List[str], int]) -> Union[str, List[str], int]:
     """
     과목명, 트랙, 마이크로디그리, 선수 과목에 문자만 사용되었는지 확인하는 함수입니다.
 


### PR DESCRIPTION
validate_string_or_sequence 함수를 확장하고 개선하기 위해 re 모듈과 sys 모듈은 별도로 사용하지 않았으며, Union과 List 타입을 사용하기 위해 from typing import Union, List 구문을 추가
-> 함수 시그니처 변경
         : value 파라미터의 타입을 Union[str, List[str], int]으로 변경하여 정수형 데이터도 지원합니다. 