### PR TITLE
'-s' 옵션 파싱 수정

### DIFF
--- a/coursegraph/__main__.py
+++ b/coursegraph/__main__.py
@@ -55,7 +55,7 @@ def main():
 
         if args.size:
             try:
-                width, height = map(int, args.size.split(','))
+                width, height = map(int, args.size.split('x'))
                 if width <= 0 or height <= 0:
                     raise ValueError
             except ValueError:


### PR DESCRIPTION
기존에는 코드에서 args.size.split('x')를 사용하여  파싱하고 있습니다. 이때 구분자로 사용하는 것이 ,인데 조금 더 표준적으로 바꾸기 위해 x로 바꿨습니다. 오류는 없지만 바꾸면 좋을 것 같습니다.
따라서 코드에서 args.size.split('x')로 변경하여 x를 구분자로 사용하는 것은 사용자가 입력하는 방식을 일반적인 사용 패턴에 맞추기 위한 것입니다.