### PR TITLE
fontutil.py 에서 시스템이 인식하지 못하는 플랫폼에 대하여 기본값 설정

### DIFF
--- a/coursegraph/fontutil.py
+++ b/coursegraph/fontutil.py
@@ -18,6 +18,9 @@ def get_system_font():
         'Darwin': {'name': 'Apple SD Gothic Neo'},
         'Linux': {'name': 'NanumGothic'}
     }
+
+    # 변경된 부분: 기본값 설정 추가
+    font_name = font_mapping.get(system, {'name': 'Default Font'})['name']
     
     for v in flist:
         try:


### PR DESCRIPTION
기존 코드에서는 특정 플랫폼에 대해 매핑되지 않으면 None이 되어서 처리되지 않는 경우가 있었습니다.
font_mapping.get(system, {'name': 'Default Font'})['name']를 사용하여 예상치 못한 플랫폼에 대해서도 기본값을 설정합니다. 
이렇게 하면, 코드가 더 안전하게 실행되며 예상치 못한 플랫폼에서 오류를 방지할 수 있습니다.