### PR TITLE
사진이 비정상적으로 확대되어 화면에 출력됨 #469

### DIFF
--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -27,8 +27,8 @@ class ShowTable:
         self.filename = input_filepath
         self.output_filename = output_filename
         self.image_mode = image_mode
-        self.width = width or 5  # 기본 너비 설정
-        self.height = height or 3  # 기본 높이 설정
+        self.width = width or 20  # 기본 너비 설정
+        self.height = height or 10  # 기본 높이 설정
 
     def get_system_font(self):
         """


### PR DESCRIPTION
width, height 기본 너비와 높이의 설정이 잘못된 값으로 되어있었습니다.

명령어> python coursegraph -o out.png data/ce.yaml