### PR TITLE
show_graph.py 학기별 과목 나눔

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -145,14 +145,21 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     if subjects is None:
         logger.error("과목 데이터가 없습니다.")
         return
+    
+    adjusted_pos_1st_semester = {}  # 1학기 과목의 위치를 저장하는 딕셔너리
+    adjusted_pos_2nd_semester = {}  # 2학기 과목의 위치를 저장하는 딕셔너리
 
+    # 1학기 과목의 위치 조정
     for subject in subjects:
         grade = int(subject['학년'])
         semester = int(subject['학기'])
         x = grade
-        y = adjusted_pos[grade].pop(0) # + semester : 학기간 간격을 주고싶다면 주석을 풀것.
-        ref[ind] = [(x, y)]
-        ind += 1
+        if semester == 1:
+            y = adjusted_pos[grade].pop(0) - 0.12 # 1학기 과목의 위치를 조정
+            adjusted_pos_1st_semester[subject['과목명']] = (x, y)
+        elif semester == 2:
+            y = adjusted_pos[grade].pop(0) + 0.12 # 2학기 과목의 위치를 조정
+            adjusted_pos_2nd_semester[subject['과목명']] = (x, y)
 
         G.add_node(subject['과목명'], pos=(x, y))
         if '선수과목' in subject:
@@ -175,7 +182,7 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     max_y = max(non_empty_positions) if non_empty_positions else 0
 
     for grade in range(1, 5):
-        G.add_node(f"{grade}학년", pos=(grade, max_y - 0.1))
+        G.add_node(f"{grade}학년", pos=(grade, max_y - 0.18))
 
     pos = nx.get_node_attributes(G, 'pos')
 
@@ -216,7 +223,7 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
 
     min_y = min(y for _, y in pos.values())
     max_y = max(y for _, y in pos.values())
-    center_y = (min_y + max_y) / 1.7
+    center_y = (min_y + max_y) / 1.75
     plt.axhline(center_y, color='black', linestyle='-', linewidth=2)
 
     # 학년별로 배경색 설정

--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -112,8 +112,7 @@ def get_edge_color(category: str) -> str:
 
     colors = {
         '전기': 'red',
-        '전선': 'blue',
-        '교필': 'green'
+        '전선': 'blue'
     }
     return colors.get(category, 'black')
 
@@ -233,8 +232,8 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
         else:
             plt.axvspan(grade - 0.5, grade + 0.5, color='lightblue', alpha=0.5)
 
-    categories = ['전기', '전선', '교필']
-    colors = ['red', 'blue', 'green']
+    categories = ['전기', '전선']
+    colors = ['red', 'blue']
     
     patches = [] # Patch 객체들을 담을 리스트 초기화
 


### PR DESCRIPTION

ce21d3b 버전의 show_graph.py 파일을 가지고 중앙선을 기준으로 하여 상단은 1학기 과목, 하단은 2학기 과목을 가리키도록 수정했습니다. 실행 결과 
![ai yaml](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/5ce9f3df-b6c9-47b8-a51a-97a0ff91b289)
![ce yaml](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/5eeb7198-3d03-475e-889d-0d993105c72e)
![input yaml](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/700365ef-c40c-48ea-ad2f-843d11cd3697)
![me yaml](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/1f720ad9-c710-495b-abb8-5e019944fa0e)
![test yml](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/1056f396-7232-4c05-9fe9-e86711249c40)
정상적으로 작동되는 것을 확인했습니다.