### PR TITLE
show_table.py에서 불필요한 반복문의 제거

### DIFF
--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -42,13 +42,12 @@ class ShowTable:
             SystemExit: 시스템 내에 적합한 한글 폰트 파일을 찾을 수 없는 경우, 오류 메시지를 출력하고 상태 코드 2로 프로그램이 종료됩니다.
         """
         system_fonts = get_system_font()
-        try:
-            for font_info in system_fonts:
-                return font_info['file']
-        except Exception:
+        if system_fonts:
+            return system_fonts[0]['file']
+        else:
             print("시스템내에 적합한 한글 폰트 파일을 찾을 수 없습니다.")
             sys.exit(2)
-
+            
     def read_subjects(self):
         """
         테이블을 생성하는데 있어서 필요한 데이터를 가져옵니다.


### PR DESCRIPTION
기존 함수에서는 get_system_font 함수에서 불필요하게 반복문을 사용하고 있습니다. 
그래서 get_system_font 함수에서 for 반복문을 제거하고, 시스템 폰트 목록이 비어 있지 않으면 첫 번째 폰트 파일을 직접 반환하도록 변경했습니다.

