### PR TITLE
schema_checker.py. 사라진 strictyaml 모듈 추가

### DIFF
--- a/coursegraph/schema_checker.py
+++ b/coursegraph/schema_checker.py
@@ -1,6 +1,7 @@
 import re
 from typing import Union, List
-
+import strictyaml
+from strictyaml import EmptyList
 
 # 과목명,트랙,마이크로디그리,선수과목에는 문자만 사용되었는지 확인하는 함수
 def validate_string_or_sequence(value: Union[str, List[str], int]) -> Union[str, List[str], int]:


### PR DESCRIPTION
837da9c50c310e083da1addf5213183ecc1e0d5a 버전에서
![image](https://github.com/oss2024hnu/coursegraph-py/assets/62284856/3a6330d3-ef9e-41cf-9d63-e5e80348842a)
 위 처럼 strictyaml 모듈을 삭제해버려서 

![image](https://github.com/oss2024hnu/coursegraph-py/assets/62284856/41c38753-3263-4864-984d-9e65e7ef8b4a)

위의 사진처럼 strictyaml을 이용한 스키마 정의에 오류가 생겨 pr 보냅니다. 