### PR TITLE
학년 노드 수정

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -189,8 +189,7 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     #학년 노드 최상단
     bbox_props = dict(boxstyle=f"round,pad=0.5", ec='black', lw=2, facecolor='white')
     for x in range(1,5):
-        plt.text(x,0, f"{x}학년", fontsize=18, ha='center', va='center', fontweight='bold', bbox=bbox_props)
-    
+        plt.text(x,-0.18, f"{x}학년", fontsize=18, ha='center', va='center', fontweight='bold', bbox=bbox_props)
     
 
     nx.draw_networkx_edges(G, pos, edgelist=edge_attrs.edgelist,


### PR DESCRIPTION
#491 이슈에서 언급한 학년 노드 수정했습니다.
![스크린샷(55)](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/b1a5bf73-a218-4669-915c-4a9c9b2466f8)
![스크린샷(56)](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/9a07ccb2-7443-4c4f-bc1e-a15c0f1061d8)
다른 파일은 그래프의 비율 때문인지는 몰라도 너무 올리면 짤려서 이 정도의 높이가 맞을 거 같습니다.