### PR TITLE
gui.py에서 파일 이름이 길 경우 잘라서 표기하는 기능 추가

### DIFF
--- a/coursegraph/gui.py
+++ b/coursegraph/gui.py
@@ -126,8 +126,13 @@ class WindowClass(QMainWindow, form_class):
                 self.label.setPixmap(scaled_pixmap)
                 self.label.adjustSize()  # QLabel 크기 조정
 
+                # 파일 이름을 QLabel에 표시 (파일 이름이 길 경우 자르기)
+                if len(filename) > 50:
+                    display_name = f"...{filename[-47:]}"
+                else:
+                    display_name = filename
+                self.statusBar().showMessage(f"Opened image: {display_name}", 5000) # 상태바에 파일 이름을 5초 동안 표시
                 self.adjustSize() # 윈도우 크기 조정
-                self.statusBar().showMessage(f"Opened image: {filename}", 5000) # 상태바에 메시지 표시
                 #self.addRecentFile(filename) # 최근 파일 목록에 추가
 
             else:
@@ -145,7 +150,15 @@ class WindowClass(QMainWindow, form_class):
             if filename:  # 파일이 선택되었는지 확인
                 pixmap = self.label.pixmap()  # QLabel에 표시된 이미지 가져오기
                 if pixmap:
-                    pixmap.save(filename)  # 이미지를 지정된 파일 경로에 저장
+                    pixmap.save(filename) # 이미지를 지정된 파일 경로에 저장
+                    
+                # 파일 이름을 QLabel에 표시 (파일 이름이 길 경우 자르기)
+                if len(filename) > 50:
+                    display_name = f"...{filename[-47:]}"
+                else:
+                    display_name = filename
+                self.statusBar().showMessage(f"Saved: {display_name}", 5000)  # 상태 표시줄에 파일 이름을 5초 동안 표시
+
                 else:
                     QMessageBox.warning(self, "Warning", "이미지가 없습니다.", QMessageBox.Ok)
         except TypeError:


### PR DESCRIPTION
'openFunction' 과 'saveAsFunction' 에서 파일 이름이 길 경우 앞부분을 생략하고 뒷부분만 표시하는 기능을 추가했습니다. 
메시지 표시 시간을  통일해 상태바 및 상태 표시줄에 메시지를 5초 동안만 표시하도록 통일했습니다.