### PR TITLE
schema_checker.py에서 불필요한 코드의 제거

### DIFF
--- a/coursegraph/schema_checker.py
+++ b/coursegraph/schema_checker.py
@@ -66,7 +66,7 @@ def validate_yaml(file_path : str):
                         raise ValueError("학년은 1부터 6까지의 정수여야 합니다.")
                     for field_name in ["과목명", "트랙", "마이크로디그리", "선수과목"]:
                         if field_name in subject:
-                            validate_string_or_sequence(subject[field_name].data)
+                            validate_string_or_sequence(subject[field_name])
                 except ValueError as e:
                     raise ValueError(f"과목 '{subject_name}'의 '{field_name}'에 유효하지 않은 값이 있습니다.") from e
             print("파일이 유효합니다.")


### PR DESCRIPTION
validate_string_or_sequence 함수 호출 시 .data 접근 방식을 제거했습니다.
불필요한 .data를 없애도 함수의 동작이나 목적은 변함이 없습니다.
그러나 .data를 명시적으로 사용하지 않아서 코드가 좀 더 직관적이게 됩니다.