### PR TITLE
show_dot.py에서 비효율적인 루프 구조 개선

### DIFF
--- a/coursegraph/show_dot.py
+++ b/coursegraph/show_dot.py
@@ -53,11 +53,12 @@ def print_dot(subjects: strictyaml.YAML, output_file: Optional[str]) -> None:
             nd[subject['과목명']] = node
             nodedict[key].append(node)
 
-    for key, ns in nodedict.items():
-        # if len(ns)==0:
-             node = graph.newItem("", subGdict[key])
-             graph.styleApply("dashed",node)
-             nodedict[key].insert(0, node)
+    for key in sorted(nodedict.keys()):
+        nodes = nodedict[key]
+        if not nodes:
+            node = graph.newItem("", subGdict[key])
+            graph.styleApply("dashed", node)
+            nodedict[key].append(node)
 
     # maxh = max(map(len,nodedict.values()))
     # for key, ns in nodedict.items():


### PR DESCRIPTION
이전 코드에서는 노드가 없는 경우를 처리하는 로직이 주석 처리되어 있습니다. 
'subGdict' 및 'nodedict' 를 딕셔너리 컴프리헨션을 사용해 초기화하고, 모든 학기별 노드를 먼저 생성한 뒤, 노드 연결 처리를 개선했습니다.
각 과목과 관련된 스타일 적용 또한 한 곳에서 처리되어, 노드 생성 로직과의 중복을 제거