### PR TITLE
graph 전필 추가

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -121,7 +121,8 @@ def get_edge_color(category: str) -> str:
 
     colors = {
         '전기': 'red',
-        '전선': 'blue'
+        '전선': 'blue',
+        '전필': 'green'
     }
     return colors.get(category, 'black')
 
@@ -221,8 +222,8 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
         else:
             plt.axvspan(grade - 0.5, grade + 0.5, color='lightblue', alpha=0.5)
 
-    categories = ['전기', '전선']
-    colors = ['red', 'blue']
+    categories = ['전기', '전선', '전필']
+    colors = ['red', 'blue', 'green']
     
     patches = [] # Patch 객체들을 담을 리스트 초기화
 


### PR DESCRIPTION
#537 이슈의 내용을 수정했습니다.
![스크린샷(62)](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/a98e789e-7b79-4c11-a1df-f2b15e67ee82)
![스크린샷(63)](https://github.com/oss2024hnu/coursegraph-py/assets/162093089/7d2f5eaa-4cbe-4878-941e-38c5ccab9a52)
전필에 대한 색상을 추가하고 오른쪽 하단에도 색상과 전필을 추가했습니다.