### PR TITLE
show_table.py 유효성 검사 코드 추가

### DIFF
--- a/coursegraph/show_table.py
+++ b/coursegraph/show_table.py
@@ -68,6 +68,8 @@ class ShowTable:
             with open(self.filename, 'r', encoding='UTF8') as file:
                 yaml_data = file.read()
                 data = syaml.load(yaml_data).data
+                if not isinstance(data, dict) or '과목' not in data:
+                    raise ValueError("유효한 데이터 형식이 아닙니다.")
                 return data
         except FileNotFoundError:
             print("파일을 찾을 수 없습니다.")


### PR DESCRIPTION
#546 에서
def read_subjects(self) 함수에
```
 if not isinstance(data, dict) or '과목' not in data:
                    raise ValueError("유효한 데이터 형식이 아닙니다.")
```
를 추가하여 data가 딕셔너리 형식이어야하고, 딕셔너리 안에 '과목'이라는 키가 반드시 포함되어있어야 하는 조건을 만들어 이 조건을 만족하지 않으면, 오류가 난다는 것을 알려주어 사용자가 쉽게 오류를 찾을 수 있게 유효성 검사 코드를 추가하였습니다.