### PR TITLE
show_graph.py에서 그래프의 엣지 색상 및 두께 추가

### DIFF
--- a/coursegraph/show_graph.py
+++ b/coursegraph/show_graph.py
@@ -194,13 +194,18 @@ def draw_course_structure(subjects: Optional[strictyaml.YAML], output_file: str,
     for y in range(1,3):
         plt.text(0.15,y-0.5, f"{y}학기", fontsize=18, ha='center', va='center', fontweight='bold', bbox=bbox_props)
 
+    # 엣지 색상 및 두께 설정
+    edge_colors = ['blue' for _ in range(len(edge_attrs.edgelist))]  # 모든 엣지를 파란색으로 설정
+    edge_widths = [2.0 for _ in range(len(edge_attrs.edgelist))]   # 모든 엣지의 두께를 2.0으로 설정
+
     nx.draw_networkx_edges(G, pos, edgelist=edge_attrs.edgelist,
                        arrowstyle=edge_attrs.arrowstyle,
                        connectionstyle='arc3,rad=0',
-                       arrowsize=50,
+                       arrowsize=edge_attrs.arrowsize,  
                        min_source_margin=20,
                        min_target_margin=70,
-                       width=2.0)
+                       edge_color=edge_colors,
+                       width=edge_widths)
 
     plt.title("과목 이수 체계도")
     plt.xlabel('학년')


### PR DESCRIPTION
'edge_colors' 리스트를 사용하여 모든 엣지를 파란색으로 설정하였고,
'edge_widths' 리스트를 사용하여 모든 엣지의 두께를 2.0으로 설정하였습니다.
이렇게 하면 각 엣지의 색상과 두께를 일괄적으로 지정할 수 있습니다.